### PR TITLE
Render child of MainLayout when state is changed

### DIFF
--- a/components/ui/MainLayout.tsx
+++ b/components/ui/MainLayout.tsx
@@ -26,7 +26,8 @@ export const MainLayout: FC<PropsWithChildren<MetaHeadProps>> = memo(
     prev.metaTitle === next.metaTitle &&
     prev.metaDescription === next.metaDescription &&
     prev.metaImage === next.metaImage &&
-    prev.metaUrl === next.metaUrl
+    prev.metaUrl === next.metaUrl &&
+    prev.children === next.children
 );
 
 MainLayout.displayName = 'MainLayout';


### PR DESCRIPTION
First of all, thanks a lot for the template!

## Child of MainLayout not re-rendered
The root component of the child of **MainLayout** is not re-rendered after changing the state.
It affects just to the _root component_, the tree is re-rendered upon the state changes.

> This behaviour is confusing when using hooks on nextjs pages because changes are not reflected in the page but in the children components.

### How to reproduce
1. Create a nextjs page as below
```javascript
const Home: NextPage = () => {
  const { address } = useAccount()
  return (
    <MainLayout>
      <HeaderMenu>
        <HeaderMenuButtons enabled={['auth']} />
      </HeaderMenu>
      <h1>### {address} ###</h1>
      <GetUserDataDemo />
   <MainLayout>
)
```
3. Connect your Elrond account
4. The value of _address_ inside `<h1>` is not updated but the same value in component _GetUserDataDemo_ is updated

