### PR TITLE
Update layout.tsx to include referrer in Metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,7 @@ const globalImage = `${dappHostname}/og-image.png`;
 export const metadata: Metadata = {
   metadataBase: new URL(dappHostname!),
   title: globalTitle,
+  referrer: "strict-origin-when-cross-origin",
   description: globalDescription,
   authors: { name: 'xDevGuild', url: 'https://www.xdevguild.com' },
   openGraph: {


### PR DESCRIPTION
Adding referrer metadata for web wallet functioning.

When deploying the website in build mode, the MultiversX web wallet site is not able to recognize who is calling it when trying to authenticate with .pem or keystore files. Therefore, the authentication fails.

Adding the referrer as strict-origin-when-crossorigin enforces that information is passed to the webwallet site.